### PR TITLE
Dependencies upgraded and travis CI enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: java
+
+script:
+  - mvn verify
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: java
 
+jdk:
+  - oraclejdk11
+  - openjdk8
+  - openjdk11
+  - openjdk-ea
+  
 script:
   - mvn verify
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # musa-client
+[![Build Status](https://travis-ci.org/hellman-and-hero/musa-client.svg?branch=master)](https://travis-ci.org/hellman-and-hero/musa-client)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=hellman-and-hero/musa-client)](https://dependabot.com)
 
 This is the *M*ost *U*gly *S*wing *A*pplication. But "*U*" could also stand for useless, unfeasible or something similar. 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # musa-client
+[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=hellman-and-hero/musa-client)](https://dependabot.com)
 
 This is the *M*ost *U*gly *S*wing *A*pplication. But "*U*" could also stand for useless, unfeasible or something similar. 
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.0</version>
+				<version>3.8.1</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
                         <plugin>
                                 <groupId>org.codehaus.mojo</groupId>
                                 <artifactId>exec-maven-plugin</artifactId>
-                                <version>1.6.0</version>
+                                <version>3.0.0</version>
                                 <configuration>
                                         <mainClass>musa.app.MusaClient</mainClass>
                                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<dependency>
 			<groupId>org.eclipse.paho</groupId>
 			<artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-			<version>1.2.1</version>
+			<version>1.2.5</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Updates of dependencies: 
- exec-maven-plugin from 1.6.0 to 3.0.0
- org.eclipse.paho.client.mqttv3 from 1.2.1 to 1.2.5
- maven-compiler-plugin from 3.8.0 to 3.8.1

Travis CI with matrix build enabled 

README with badges added